### PR TITLE
Fix StatClient AccessToken issue

### DIFF
--- a/src/Yandex/Metrica/Stat/StatClient.php
+++ b/src/Yandex/Metrica/Stat/StatClient.php
@@ -28,6 +28,6 @@ class StatClient extends MetricaClient
      */
     public function data()
     {
-        return new DataClient();
+        return new DataClient($this->getAccessToken());
     }
 }


### PR DESCRIPTION
Решение проблемы с отсутствием Access токена в DataClient после создания экземпляра с помощью метода StatClient*->data().