### PR TITLE
Fix file upload

### DIFF
--- a/src/Yandex/Disk/DiskClient.php
+++ b/src/Yandex/Disk/DiskClient.php
@@ -355,9 +355,6 @@ class DiskClient extends AbstractServiceClient
             $headers['Content-Type'] = $parts[0];
             $headers['Etag'] = md5_file($file['path']);
             $headers['Sha256'] = hash_file('sha256', $file['path']);
-            $headers['Host'] = $this->getServiceDomain();
-            $headers['Accept'] = '*/*';
-            $headers['Authorization'] = 'OAuth ' . $this->getAccessToken();
             $headers = isset($extraHeaders) ? array_merge($headers, $extraHeaders) : $headers;
 
             $client = new Client();
@@ -366,7 +363,8 @@ class DiskClient extends AbstractServiceClient
                 $this->getServiceUrl(),
                 [
                     'headers' => $headers,
-                    'body' => '@' .$file['path']
+                    'body' => fopen($file['path'], 'r'),
+                    'expect' => true
                 ]
             );
             $request->setPath($path . $file['name']);


### PR DESCRIPTION
Closes #112 .
В ходе инвестигейта #112 еще раз перечитал доку по [wedav api](https://tech.yandex.com/disk/doc/dg/reference/put-docpage/) и следом смотрел [доку к guzzle](https://guzzle.readthedocs.org/en/5.3/clients.html).

Через некоторое время запустив загрузку с опцией debug заметил отсутствие 'expect' заголовка при загрузке из библиотеки.

Так же понял, что я ошибся по поводу синтаксиса передачи содержимого файла в запросе без чтения всего файла - это тоже поправил.