### PR TITLE
Add ability to set proxy for client

### DIFF
--- a/src/Yandex/Common/AbstractServiceClient.php
+++ b/src/Yandex/Common/AbstractServiceClient.php
@@ -11,6 +11,7 @@
  */
 namespace Yandex\Common;
 
+use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Message\RequestInterface;
@@ -64,6 +65,11 @@ abstract class AbstractServiceClient extends AbstractPackage
     /**
      * @var string
      */
+    protected $proxy = '';
+
+    /**
+     * @var string
+     */
     protected $libraryName = 'yandex-php-library';
 
     /**
@@ -93,6 +99,26 @@ abstract class AbstractServiceClient extends AbstractPackage
     {
         return $this->accessToken;
     }
+
+    /**
+     * @param $proxy
+     * @return $this
+     */
+    public function setProxy($proxy)
+    {
+        $this->proxy = $proxy;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProxy()
+    {
+        return $this->proxy;
+    }
+
 
     /**
      * @param string $serviceDomain
@@ -171,6 +197,18 @@ abstract class AbstractServiceClient extends AbstractPackage
     protected function doCheckSettings()
     {
         return true;
+    }
+
+    /**
+     * @return \GuzzleHttp\ClientInterface
+     */
+    protected function getClient()
+    {
+        $client = new Client();
+        if ($this->getProxy()) {
+            $client->setDefaultOption('proxy', $this->getProxy());
+        }
+        return $client;
     }
 
     /**

--- a/src/Yandex/Dictionary/DictionaryClient.php
+++ b/src/Yandex/Dictionary/DictionaryClient.php
@@ -285,7 +285,7 @@ class DictionaryClient extends AbstractServiceClient
     public function lookup($text)
     {
         $url = $this->getLookupUrl($text);
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $url, ['version' => $this->serviceProtocolVersion]);
         $response = $this->sendRequest($client, $request);
         if ($response->getStatusCode() === 200) {
@@ -304,7 +304,7 @@ class DictionaryClient extends AbstractServiceClient
     public function getLanguages()
     {
         $url = $this->getGetLanguagesUrl();
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $url, ['version' => $this->serviceProtocolVersion]);
         $response = $this->sendRequest($client, $request);
         if ($response->getStatusCode() === 200) {

--- a/src/Yandex/Disk/DiskClient.php
+++ b/src/Yandex/Disk/DiskClient.php
@@ -117,7 +117,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function createDirectory($path = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('MKCOL', $this->getServiceUrl());
         $request->setPath($path);
         return (bool)$this->sendRequest($client, $request);
@@ -131,7 +131,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function directoryContents($path = '', $offset = null, $amount = null)
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('PROPFIND', $this->getServiceUrl());
         $request->setPath($path);
         $request->setHeader('Depth', '1');
@@ -167,7 +167,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function diskSpaceInfo()
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $body = '<?xml version="1.0" encoding="utf-8" ?><D:propfind xmlns:D="DAV:">
             <D:prop><D:quota-available-bytes/><D:quota-used-bytes/></D:prop></D:propfind>';
@@ -202,7 +202,7 @@ class DiskClient extends AbstractServiceClient
     public function setProperty($path = '', $property = '', $value = '', $namespace = 'default:namespace')
     {
         if (!empty($property) && !empty($value)) {
-            $client = new Client();
+            $client = $this->getClient();
 
             $body = '<?xml version="1.0" encoding="utf-8" ?><propertyupdate xmlns="DAV:" xmlns:u="'
                 . $namespace . '"><set><prop><u:' . $property . '>' . $value . '</u:'
@@ -239,7 +239,7 @@ class DiskClient extends AbstractServiceClient
     public function getProperty($path = '', $property = '', $namespace = 'default:namespace')
     {
         if (!empty($property)) {
-            $client = new Client();
+            $client = $this->getClient();
 
             $body = '<?xml version="1.0" encoding="utf-8" ?><propfind xmlns="DAV:"><prop><' . $property
                 . ' xmlns="' . $namespace . '"/></prop></propfind>';
@@ -275,7 +275,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function getLogin()
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'GET',
             parent::getServiceUrl() . '?userinfo'
@@ -294,7 +294,7 @@ class DiskClient extends AbstractServiceClient
     public function getFile($path = '')
     {
         $result = array();
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl());
         $request->setPath($path);
 
@@ -315,7 +315,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function downloadFile($path = '', $destination = '', $name = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl());
         $request->setPath($path);
         $response = $this->sendRequest($client, $request);
@@ -357,14 +357,15 @@ class DiskClient extends AbstractServiceClient
             $headers['Sha256'] = hash_file('sha256', $file['path']);
             $headers = isset($extraHeaders) ? array_merge($headers, $extraHeaders) : $headers;
 
-            $client = new Client();
+            $client = $this->getClient();
             $request = $client->createRequest(
                 'PUT',
                 $this->getServiceUrl(),
                 [
                     'headers' => $headers,
                     'body' => fopen($file['path'], 'rb'),
-                    'expect' => true
+                    'expect' => true,
+                    'debug' => true
                 ]
             );
             $request->setPath($path . $file['name']);
@@ -380,7 +381,7 @@ class DiskClient extends AbstractServiceClient
     public function getImagePreview($path, $size)
     {
         $result = array();
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl());
         $request->setPath($path);
         $request->getQuery()->set('preview', null);
@@ -403,7 +404,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function copy($target = '', $destination = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('COPY', $this->getServiceUrl());
         $request->setPath($target);
         $request->setHeader('Destination', $destination);
@@ -417,7 +418,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function move($path = '', $destination = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('MOVE', $this->getServiceUrl());
         $request->setPath($path);
         $request->setHeader('Destination', $destination);
@@ -430,7 +431,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function delete($path = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('DELETE', $this->getServiceUrl());
         $request->setPath($path);
         return (bool)$this->sendRequest($client, $request);
@@ -442,7 +443,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function startPublishing($path = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $body = '<propertyupdate xmlns="DAV:"><set><prop>
             <public_url xmlns="urn:yandex:disk:meta">true</public_url>
@@ -471,7 +472,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function stopPublishing($path = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $body = '<propertyupdate xmlns="DAV:"><remove><prop>
             <public_url xmlns="urn:yandex:disk:meta" />
@@ -498,7 +499,7 @@ class DiskClient extends AbstractServiceClient
      */
     public function checkPublishing($path = '')
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $body = '<propfind xmlns="DAV:"><prop><public_url xmlns="urn:yandex:disk:meta"/></prop></propfind>';
 

--- a/src/Yandex/Market/Partner/PartnerClient.php
+++ b/src/Yandex/Market/Partner/PartnerClient.php
@@ -273,7 +273,7 @@ class PartnerClient extends AbstractServiceClient
     {
         $resource = 'campaigns.json';
 
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl($resource));
         $response = $this->sendRequest($client, $request)->json();
         $getCampaignsResponse = new Models\GetCampaignsResponse($response);
@@ -299,7 +299,7 @@ class PartnerClient extends AbstractServiceClient
         $resource = 'campaigns/' . $this->campaignId . '/orders.json';
         $resource .= '?' . http_build_query($params);
 
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl($resource));
 
         $response = $this->sendRequest($client, $request)->json();
@@ -331,7 +331,7 @@ class PartnerClient extends AbstractServiceClient
     {
         $resource = 'campaigns/' . $this->campaignId . '/orders/' . $orderId . '.json';
 
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl($resource));
 
         $response = $this->sendRequest($client, $request)->json();
@@ -365,7 +365,7 @@ class PartnerClient extends AbstractServiceClient
 
         $data = json_encode($data);
 
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'PUT',
             $this->getServiceUrl($resource),
@@ -397,7 +397,7 @@ class PartnerClient extends AbstractServiceClient
     {
         $resource = 'campaigns/' . $this->campaignId . '/orders/' . $orderId . '/delivery.json';
         $data = json_encode($delivery->toArray());
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'PUT',
             $this->getServiceUrl($resource),

--- a/src/Yandex/Metrica/MetricaClient.php
+++ b/src/Yandex/Metrica/MetricaClient.php
@@ -133,8 +133,7 @@ class MetricaClient extends AbstractServiceClient
      */
     protected function sendGetRequest($resource, $params = array())
     {
-
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'GET',
             $this->getServiceUrl($resource, $params),
@@ -166,7 +165,7 @@ class MetricaClient extends AbstractServiceClient
      */
     protected function getNextPartOfList($url, $data = array())
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'GET',
             $url,
@@ -201,7 +200,7 @@ class MetricaClient extends AbstractServiceClient
      */
     protected function sendPostRequest($resource, $params)
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $request = $client->createRequest(
             'POST',
@@ -230,7 +229,7 @@ class MetricaClient extends AbstractServiceClient
      */
     protected function sendPutRequest($resource, $params)
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $request = $client->createRequest(
             'PUT',
@@ -258,7 +257,7 @@ class MetricaClient extends AbstractServiceClient
      */
     protected function sendDeleteRequest($resource)
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $request = $client->createRequest(
             'DELETE',

--- a/src/Yandex/OAuth/OAuthClient.php
+++ b/src/Yandex/OAuth/OAuthClient.php
@@ -251,7 +251,7 @@ class OAuthClient
      */
     public function requestAccessToken($code)
     {
-        $client = new Client();
+        $client = $this->getClient();
 
         $request = $client->createRequest(
             'POST',

--- a/src/Yandex/SafeBrowsing/SafeBrowsingClient.php
+++ b/src/Yandex/SafeBrowsing/SafeBrowsingClient.php
@@ -185,7 +185,7 @@ class SafeBrowsingClient extends AbstractServiceClient
     public function checkHash($bodyString = '')
     {
         $resource = 'gethash';
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'POST',
             $this->getServiceUrl($resource),
@@ -208,7 +208,7 @@ class SafeBrowsingClient extends AbstractServiceClient
     public function getChunks($bodyString = '')
     {
         $resource = 'downloads';
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest(
             'POST',
             $this->getServiceUrl($resource),
@@ -230,7 +230,7 @@ class SafeBrowsingClient extends AbstractServiceClient
     public function getShavarsList()
     {
         $resource = 'list';
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $this->getServiceUrl($resource));
         $response = $this->sendRequest($client, $request);
         return explode("\n", trim($response->getBody()));
@@ -243,7 +243,7 @@ class SafeBrowsingClient extends AbstractServiceClient
     public function lookup($url)
     {
         $url = $this->getLookupUrl($url);
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $url);
         $response = $this->sendRequest($client, $request);
         if ($response->getStatusCode() === 200) {
@@ -259,7 +259,7 @@ class SafeBrowsingClient extends AbstractServiceClient
     public function checkAdult($url)
     {
         $url = $this->getCheckAdultUrl($url);
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $url);
         $response = $this->sendRequest($client, $request);
         if ($response->getBody() === 'adult') {
@@ -274,7 +274,7 @@ class SafeBrowsingClient extends AbstractServiceClient
      */
     public function getChunkByUrl($url)
     {
-        $client = new Client();
+        $client = $this->getClient();
         $request = $client->createRequest('GET', $url);
         $request->setHeader('Accept', '*/*');
         $response = $this->sendRequest($client, $request);

--- a/src/Yandex/SiteSearchPinger/SiteSearchPinger.php
+++ b/src/Yandex/SiteSearchPinger/SiteSearchPinger.php
@@ -211,7 +211,7 @@ class SiteSearchPinger extends AbstractServiceClient
      */
     protected function doRequest($urls, $publishDate)
     {
-        $client = new Client();
+        $client = $this->getClient();
         $client->setDefaultOption('headers', ['Y-SDK' => 'Pinger']);
         $client->setDefaultOption(
             'query',


### PR DESCRIPTION
Добавлена возможность задать прокси для клиента.
Например для диска это можно сделать следующим образом
```
use Yandex\Disk\DiskClient;
$accessToken = getenv('ACCESS_TOKEN');
$diskClient = new DiskClient($accessToken);

// Задаем прокси
$diskClient->setProxy('https://proxy.com:3128');

$diskClient->setServiceScheme(DiskClient::HTTPS_SCHEME);
$result = $diskClient->diskSpaceInfo();
```
Аналогично работает и для остальных клиентов.

Closes #88 