### PR TITLE
Fix getMalwaresData calls for shavars without 204

### DIFF
--- a/src/Yandex/Common/AbstractServiceClient.php
+++ b/src/Yandex/Common/AbstractServiceClient.php
@@ -246,7 +246,9 @@ abstract class AbstractServiceClient extends AbstractPackage
     protected function prepareRequest(RequestInterface $request)
     {
         $request->setHeader('Authorization', 'OAuth ' . $this->getAccessToken());
-        $request->setHeader('Host', $this->getServiceDomain());
+        if (!$request->hasHeader('Host')) {
+            $request->setHeader('Host', $this->getServiceDomain());
+        }
         $request->setHeader('User-Agent', $this->getUserAgent());
         $request->setHeader('Accept', '*/*');
         return $request;

--- a/src/Yandex/Common/Exception/NotFoundException.php
+++ b/src/Yandex/Common/Exception/NotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Yandex PHP Library
+ *
+ * @copyright NIX Solutions Ltd.
+ * @link https://github.com/nixsolutions/yandex-php-library
+ */
+
+/**
+ * @namespace
+ */
+namespace Yandex\Common\Exception;
+
+/**
+ * Forbidden Exception
+ *
+ * @package  Yandex\Common\Exception
+ *
+ * @author   Dmitriy Savchenko <login.was.here@gmail.com>
+ * @created  09.10.15 12:27
+ */
+class NotFoundException extends YandexException
+{
+}


### PR DESCRIPTION
Этот пул реквест изправляет работу Yandex\SafeBrowsing\SafeBrowsingClient::getMalwaresData для malwareShavars по умолчанию
```
protected $malwareShavars = array(
    'ydx-malware-shavar',
    'ydx-phish-shavar',
    'goog-malware-shavar',
    'goog-phish-shavar'
);
```
и для malwareShavars полученных в ответе от Yandex\SafeBrowsing\SafeBrowsingClient::getShavarsList, кроме "ydx-mitb-uids".

Более подробно проблема описана в #70 