### PR TITLE
Yandex Metrika: dimensions, sort and metrics can be string list

### DIFF
--- a/src/Yandex/Common/StringCollection.php
+++ b/src/Yandex/Common/StringCollection.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Yandex\Common;
+
+use Yandex\Common\Exception\InvalidArgumentException;
+
+/**
+ * String collection
+ *
+ * @category Yandex
+ * @package  Common
+ *
+ * @author   Vasilii Zaluev
+ * @created  17.03.16 22:31
+ */
+class StringCollection
+{
+   /**
+    * This string collection will convert to one string in get request by join
+    *
+    * @var string
+    */
+   protected $collection = [];
+
+   public function __construct($strings)
+   {
+      foreach($strings as $string){
+         if(!self::isString($string)){
+            throw new InvalidArgumentException('Argument must have only strings');
+         }
+
+         $this->collection[] = $string;
+      }
+   }
+
+   /**
+    * @param $strings
+    * @return null|self
+    * @throws InvalidArgumentException
+    */
+   public static function init($strings)
+   {
+      if (is_null($strings)) {
+         return null;
+      }
+
+      if (self::isString($strings)) {
+         return new static([$strings]);
+      }
+
+      if (is_array($strings)){
+         if(empty($strings)){
+            return null;
+         }
+
+         return new self($strings);
+      }
+
+      throw new InvalidArgumentException('Argument must be string or string list, ' . gettype($strings) . ' received');
+   }
+
+   public function getAll()
+   {
+      return implode(',', $this->collection);
+   }
+
+   private static function isString($string)
+   {
+      return is_string($string) || method_exists($string, '__toString');
+   }
+
+   public function asArray()
+   {
+      return $this->collection;
+   }
+}

--- a/src/Yandex/Common/StringCollection.php
+++ b/src/Yandex/Common/StringCollection.php
@@ -10,67 +10,67 @@ use Yandex\Common\Exception\InvalidArgumentException;
  * @category Yandex
  * @package  Common
  *
- * @author   Vasilii Zaluev
- * @created  17.03.16 22:31
+ * @author  Vasilii Zaluev
+ * @created 17.03.16 22:31
  */
 class StringCollection
 {
-   /**
+    /**
     * This string collection will convert to one string in get request by join
     *
     * @var string
     */
-   protected $collection = [];
+    protected $collection = [];
 
-   public function __construct($strings)
-   {
-      foreach($strings as $string){
-         if(!self::isString($string)){
-            throw new InvalidArgumentException('Argument must have only strings');
-         }
+    public function __construct($strings)
+    {
+        foreach ($strings as $string) {
+            if (!self::isString($string)) {
+                throw new InvalidArgumentException('Argument must have only strings');
+            }
 
-         $this->collection[] = $string;
-      }
-   }
+            $this->collection[] = $string;
+        }
+    }
 
-   /**
+    /**
     * @param $strings
     * @return null|self
     * @throws InvalidArgumentException
     */
-   public static function init($strings)
-   {
-      if (is_null($strings)) {
-         return null;
-      }
-
-      if (self::isString($strings)) {
-         return new static([$strings]);
-      }
-
-      if (is_array($strings)){
-         if(empty($strings)){
+    public static function init($strings)
+    {
+        if (is_null($strings)) {
             return null;
-         }
+        }
 
-         return new self($strings);
-      }
+        if (self::isString($strings)) {
+            return new static([$strings]);
+        }
 
-      throw new InvalidArgumentException('Argument must be string or string list, ' . gettype($strings) . ' received');
-   }
+        if (is_array($strings)) {
+            if (empty($strings)) {
+                return null;
+            }
 
-   public function getAll()
-   {
-      return implode(',', $this->collection);
-   }
+            return new self($strings);
+        }
 
-   private static function isString($string)
-   {
-      return is_string($string) || method_exists($string, '__toString');
-   }
+        throw new InvalidArgumentException('Argument must be string or string list ' . gettype($strings) . ' received');
+    }
 
-   public function asArray()
-   {
-      return $this->collection;
-   }
+    public function getAll()
+    {
+        return implode(',', $this->collection);
+    }
+
+    private static function isString($string)
+    {
+        return is_string($string) || method_exists($string, '__toString');
+    }
+
+    public function asArray()
+    {
+        return $this->collection;
+    }
 }

--- a/src/Yandex/Metrica/Stat/Models/ByTimeParams.php
+++ b/src/Yandex/Metrica/Stat/Models/ByTimeParams.php
@@ -3,6 +3,7 @@
 namespace Yandex\Metrica\Stat\Models;
 
 use Yandex\Common\Model;
+use Yandex\Common\StringCollection;
 
 class ByTimeParams extends Model
 {
@@ -11,10 +12,19 @@ class ByTimeParams extends Model
 
     protected $preset = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $dimensions = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $metrics = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $sort = null;
 
     protected $limit = null;
@@ -98,66 +108,66 @@ class ByTimeParams extends Model
     /**
      * Retrieve the dimensions property
      *
-     * @return string|null
+     * @return string[]|null
      */
     public function getDimensions()
     {
-        return $this->dimensions;
+        return is_null($this->dimensions) ? null : $this->dimensions->asArray();
     }
 
     /**
      * Set the dimensions property
      *
-     * @param string $dimensions
+     * @param string[]|string|null $dimensions
      * @return $this
      */
     public function setDimensions($dimensions)
     {
-        $this->dimensions = $dimensions;
+        $this->dimensions = StringCollection::init($dimensions);
         return $this;
     }
 
     /**
      * Retrieve the metrics property
      *
-     * @return string|null
+     * @return string[]|null
      */
     public function getMetrics()
     {
-        return $this->metrics;
+        return is_null($this->metrics) ? null : $this->metrics->asArray();
     }
 
     /**
      * Set the metrics property
      *
-     * @param string $metrics
+     * @param string[]|string|null $metrics
      * @return $this
      */
     public function setMetrics($metrics)
     {
-        $this->metrics = $metrics;
+        $this->metrics = StringCollection::init($metrics);
         return $this;
     }
 
     /**
      * Retrieve the sort property
      *
-     * @return array|null
+     * @return string[]|null
      */
     public function getSort()
     {
-        return $this->sort;
+        return is_null($this->sort) ? null : $this->sort->asArray();
     }
 
     /**
      * Set the sort property
      *
-     * @param array $sort
+     * @param string[]|string|null $sort
      * @return $this
      */
     public function setSort($sort)
     {
-        $this->sort = $sort;
+        $this->sort = StringCollection::init($sort);
         return $this;
     }
 

--- a/src/Yandex/Metrica/Stat/Models/TableParams.php
+++ b/src/Yandex/Metrica/Stat/Models/TableParams.php
@@ -3,6 +3,7 @@
 namespace Yandex\Metrica\Stat\Models;
 
 use Yandex\Common\Model;
+use Yandex\Common\StringCollection;
 
 class TableParams extends Model
 {
@@ -11,10 +12,19 @@ class TableParams extends Model
 
     protected $preset = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $dimensions = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $metrics = null;
 
+    /**
+     * @var null|StringCollection
+     */
     protected $sort = null;
 
     protected $limit = null;
@@ -90,66 +100,66 @@ class TableParams extends Model
     /**
      * Retrieve the dimensions property
      *
-     * @return string|null
+     * @return string[]|null
      */
     public function getDimensions()
     {
-        return $this->dimensions;
+        return is_null($this->dimensions) ? null : $this->dimensions->asArray();
     }
 
     /**
      * Set the dimensions property
      *
-     * @param string $dimensions
+     * @param string|string[]|null $dimensions
      * @return $this
      */
     public function setDimensions($dimensions)
     {
-        $this->dimensions = $dimensions;
+        $this->dimensions = StringCollection::init($dimensions);
         return $this;
     }
 
     /**
      * Retrieve the metrics property
      *
-     * @return string|null
+     * @return string[]|null
      */
     public function getMetrics()
     {
-        return $this->metrics;
+        return is_null($this->metrics) ? null : $this->metrics->asArray();
     }
 
     /**
      * Set the metrics property
      *
-     * @param string $metrics
+     * @param string[]|string|null $metrics
      * @return $this
      */
     public function setMetrics($metrics)
     {
-        $this->metrics = $metrics;
+        $this->metrics = StringCollection::init($metrics);
         return $this;
     }
 
     /**
      * Retrieve the sort property
      *
-     * @return string|null
+     * @return string[]|null
      */
     public function getSort()
     {
-        return $this->sort;
+        return is_null($this->sort) ? null : $this->sort->asArray();
     }
 
     /**
      * Set the sort property
      *
-     * @param string $sort
+     * @param string|string[]|null $sort
      * @return $this
      */
     public function setSort($sort)
     {
-        $this->sort = $sort;
+        $this->sort = StringCollection::init($sort);
         return $this;
     }
 

--- a/tests/Yandex/Tests/Common/StringCollectionTest.php
+++ b/tests/Yandex/Tests/Common/StringCollectionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yandex\Tests\Common;
+
+
+use Yandex\Common\StringCollection;
+use Yandex\Metrica\Stat\Models\ByTimeParams;
+
+class StringCollectionTest extends \PHPUnit_Framework_TestCase
+{
+
+   public function testNullArgumentReceived()
+   {
+      $this->assertEquals(null, StringCollection::init(null));
+   }
+
+   public function testStringArgumentReceived()
+   {
+      $string = '12';
+      $collection = StringCollection::init($string);
+      $this->assertEquals([$string], $collection->asArray());
+   }
+
+   public function testStringListArgumentReceived()
+   {
+      $stringList = ['1', '2'];
+      $collection = StringCollection::init($stringList);
+      $this->assertEquals($stringList, $collection->asArray());
+   }
+
+   public function testJoinStrings()
+   {
+      $stringList = ['1', '2'];
+      $collection = StringCollection::init($stringList);
+      $this->assertEquals('1,2', $collection->getAll());
+   }
+
+   public function testCorrectObjectReceived()
+   {
+      $object = new ConvertibleObject();
+      $collection = StringCollection::init($object);
+      $this->assertEquals([$object], $collection->asArray());
+   }
+
+   public function testArrayHasCorrectObjectReceived()
+   {
+      $array = [new ConvertibleObject(), '1'];
+      $collection = StringCollection::init($array);
+      $this->assertEquals($array, $collection->asArray());
+   }
+
+   /**
+    * @expectedException \Yandex\Common\Exception\InvalidArgumentException
+    */
+   public function testNonCorrectObjectReceived()
+   {
+      $object = new NonConvertibleObject();
+      $collection = StringCollection::init($object);
+      $this->assertEquals([$object], $collection->asArray());
+   }
+
+   /**
+    * @expectedException \Yandex\Common\Exception\InvalidArgumentException
+    */
+   public function testArrayHasNonCorrectObjectReceived()
+   {
+      $array = [new NonConvertibleObject(), '1'];
+      $collection = StringCollection::init($array);
+      $this->assertEquals([$array], $collection->asArray());
+   }
+
+   public function testEmptyArrayReceived()
+   {
+      $this->assertEquals(null, StringCollection::init([]));
+   }
+
+   public function test1()
+   {
+      $param = new ByTimeParams();
+      $param->setDimensions(['12', '13'])->setLimit(10);
+      $expected = [
+         'dimensions' => '12,13',
+         'limit' => 10,
+      ];
+      $this->assertEquals($expected, $param->toArray());
+   }
+}
+
+class ConvertibleObject
+{
+   public function __toString()
+   {
+      return '1';
+   }
+}
+
+class NonConvertibleObject
+{
+}

--- a/tests/Yandex/Tests/Metrica/DataClientTest.php
+++ b/tests/Yandex/Tests/Metrica/DataClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Yandex\Tests\Metrica;
 
+use Yandex\Metrica\Stat\DataClient;
 use Yandex\Tests\Metrica\Fixtures\Stat;
 use Yandex\Tests\TestCase;
 use Yandex\Metrica\Stat\Models;
@@ -198,5 +199,25 @@ class DataClientTest extends TestCase
         $this->assertEquals($fixtures["data_lag"], $table->getDataLag());
         $this->assertEquals($fixtures["totals"]["a"], $table->getTotals()->getA());
         $this->assertEquals($fixtures["totals"]["b"], $table->getTotals()->getB());
+    }
+
+    public function testGenerateRequest()
+    {
+        $id = 123;
+        $limit = 100;
+        $dimensions = ['dimension1', 'deimension2'];
+        $sort = 'sort';
+        $filter = 'a<b';
+        $byTimeParams = new Models\ByTimeParams();
+        $byTimeParams->setId($id)
+            ->setLimit($limit)
+            ->setDimensions($dimensions)
+            ->setSort($sort)
+            ->setFilters($filter)
+            ->setMetrics(null);
+        $client = new DataClient();
+        $url = $client->getServiceUrl('bytime', $byTimeParams->toArray());
+        $expectedUrl = 'https://api-metrika.yandex.ru/stat/v1/data/bytime.json?oauth_token=&id=123&dimensions=dimension1%2Cdeimension2&sort=sort&limit=100&filters=a%3Cb';
+        $this->assertEquals($expectedUrl, $url);
     }
 }

--- a/tests/Yandex/Tests/Metrica/DataClientTest.php
+++ b/tests/Yandex/Tests/Metrica/DataClientTest.php
@@ -217,7 +217,8 @@ class DataClientTest extends TestCase
             ->setMetrics(null);
         $client = new DataClient();
         $url = $client->getServiceUrl('bytime', $byTimeParams->toArray());
-        $expectedUrl = 'https://api-metrika.yandex.ru/stat/v1/data/bytime.json?oauth_token=&id=123&dimensions=dimension1%2Cdeimension2&sort=sort&limit=100&filters=a%3Cb';
+        $expectedUrl = 'https://api-metrika.yandex.ru/stat/v1/data/bytime.json?oauth_token=&id=' . $id . '&dimensions='
+              . urlencode(implode(',', $dimensions)) . '&sort=' . $sort . '&limit=' . $limit . '&filters=' . urlencode($filter);
         $this->assertEquals($expectedUrl, $url);
     }
 }


### PR DESCRIPTION
Теперь строки группировки, сортировки и метрики можно указывать в виде массива строчек. Правда получилось как-то громоздко.