### PR TITLE
Allow to use custom \GuzzleHttp\ClientInterface

### DIFF
--- a/src/Yandex/Metrica/MetricaClient.php
+++ b/src/Yandex/Metrica/MetricaClient.php
@@ -11,6 +11,7 @@
  */
 namespace Yandex\Metrica;
 
+use GuzzleHttp\ClientInterface;
 use Yandex\Common\AbstractServiceClient;
 use Psr\Http\Message\UriInterface;
 use GuzzleHttp\Psr7\Response;
@@ -41,10 +42,14 @@ class MetricaClient extends AbstractServiceClient
 
     /**
      * @param string $token access token
+     * @param ClientInterface $client
      */
-    public function __construct($token = '')
+    public function __construct($token = '', ClientInterface $client = null)
     {
         $this->setAccessToken($token);
+        if (!is_null($client)) {
+            $this->setClient($client);
+        }
     }
 
     /**

--- a/src/Yandex/Metrica/Stat/StatClient.php
+++ b/src/Yandex/Metrica/Stat/StatClient.php
@@ -28,6 +28,6 @@ class StatClient extends MetricaClient
      */
     public function data()
     {
-        return new DataClient($this->getAccessToken());
+        return new DataClient($this->getAccessToken(), $this->client);
     }
 }

--- a/tests/Yandex/Tests/Metrica/MetricaClientTest.php
+++ b/tests/Yandex/Tests/Metrica/MetricaClientTest.php
@@ -38,6 +38,13 @@ class MetricaClientTest extends TestCase
         $this->assertEquals($token, $metricaClient->getAccessToken());
     }
 
+    public function testConstructWithCustomGuzzleClient()
+    {
+        $token = 'test';
+        $metricaClient = new MetricaClient($token, $this->getMock('GuzzleHttp\Client'));
+        $this->assertEquals($token, $metricaClient->getAccessToken());
+    }
+
     function testSendRequestForbiddenException()
     {
         $token                = 'test';

--- a/tests/Yandex/Tests/Metrica/StatClientTest.php
+++ b/tests/Yandex/Tests/Metrica/StatClientTest.php
@@ -33,4 +33,16 @@ class StatClientTest extends TestCase
         $this->assertTrue($client instanceof DataClient);
         $this->assertEquals($token, $client->getAccessToken());
     }
+
+    /**
+     * @covers StatClient::data
+     */
+    public function testMethodDataWithCustomClient()
+    {
+        $token      = 'test';
+        $statClient = new StatClient($token, $this->getMock('GuzzleHttp\Client'));
+        $client     = $statClient->data();
+        $this->assertTrue($client instanceof DataClient);
+        $this->assertEquals($token, $client->getAccessToken());
+    }
 }

--- a/tests/Yandex/Tests/Metrica/StatClientTest.php
+++ b/tests/Yandex/Tests/Metrica/StatClientTest.php
@@ -35,7 +35,7 @@ class StatClientTest extends TestCase
     }
 
     /**
-     * @covers StatClient::data
+     * @covers \Yandex\Metrica\Stat\StatClient::data
      */
     public function testMethodDataWithCustomClient()
     {


### PR DESCRIPTION
This param would allow to set some curl options for \GuzzleHttp\Client or inject any \GuzzleHttp\ClientInterface.