### PR TITLE
YAN-35 Fix issue with coveralls deprecated warning

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,3 @@
 service_name: travis-ci
-src_dir: src
 coverage_clover: .reports/clover.xml
 json_path: .reports/coveralls-upload.json


### PR DESCRIPTION
In build https://travis-ci.org/nixsolutions/yandex-php-library/jobs/174432950 I've noticed that we have errors in our .travis/after_success.sh script. It can be seen here https://s3.amazonaws.com/archive.travis-ci.org/jobs/174432950/log.txt