### PR TITLE
Fix composer update

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -16,7 +16,8 @@ fi
 
 if [ "$TRAVIS_REPO_SLUG" == "nixsolutions/yandex-php-library" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then
 
-  composer update --no-dev
+  composer update --no-dev --no-autoloader
+  composer dump-autoload --no-dev
   php phar.php
 
 fi


### PR DESCRIPTION
Workaround of composer update issue
```
composer update --prefer-source
composer update --no-dev
...
Generating autoload files

  [RuntimeException]                                                                                                                                           
  Could not scan for classes inside "/yandex-php-library/vendor/phpunit/php-token-stream/src/" which does not appear to be a file nor a folder 
```