### PR TITLE
Поддержка параметра direct_client_logins

### DIFF
--- a/src/Yandex/Metrica/Stat/Models/TableParams.php
+++ b/src/Yandex/Metrica/Stat/Models/TableParams.php
@@ -26,7 +26,12 @@ class TableParams extends Model
      * @var null|StringCollection
      */
     protected $sort = null;
-
+    
+    /**
+     * @var null|StringCollection
+     */
+    protected $directClientLogins = null;
+    
     protected $limit = null;
 
     protected $offset = null;
@@ -50,7 +55,8 @@ class TableParams extends Model
     protected $mappingClasses = [];
 
     protected $propNameMap = [
-        'include_undefined' => 'includeUndefined'
+        'include_undefined' => 'includeUndefined',
+        'direct_client_logins' => 'directClientLogins',
     ];
 
     /**
@@ -160,6 +166,28 @@ class TableParams extends Model
     public function setSort($sort)
     {
         $this->sort = StringCollection::init($sort);
+        return $this;
+    }
+    
+    /**
+     * Retrieve the directClientLogins property
+     *
+     * @return string[]|null
+     */
+    public function getDirectClientLogins()
+    {
+        return is_null($this->directClientLogins) ? null : $this->directClientLogins->asArray();
+    }
+    
+    /**
+     * Set the directClientLogins property
+     *
+     * @param string|string[]|null $directClientLogins
+     * @return $this
+     */
+    public function setDirectClientLogins($directClientLogins)
+    {
+        $this->directClientLogins = StringCollection::init($directClientLogins);
         return $this;
     }
 

--- a/tests/Yandex/Tests/Metrica/Fixtures/Stat.php
+++ b/tests/Yandex/Tests/Metrica/Fixtures/Stat.php
@@ -525,14 +525,17 @@ class Stat
             "ym:s:pageDepth",
             "ym:s:avgVisitDurationSeconds"
         ],
-        "sort"              => [
+        "sort"                 => [
             "-ym:s:visits"
+        ],
+        "direct_client_logins" => [
+            "yd-test"
         ],
         "limit"             => 100,
         "offset"            => 1,
         'filters'           => "ym:s:isMobile!='Yes'",
-        "date1"           => "2014-07-16",
-        "date2"           => "2014-07-22",
+        "date1"             => "2014-07-16",
+        "date2"             => "2014-07-22",
         'accuracy'          => 'medium',
         'callback'          => null,
         'include_undefined' => true,

--- a/tests/Yandex/Tests/Metrica/Models/Stat/TableParamsTest.php
+++ b/tests/Yandex/Tests/Metrica/Models/Stat/TableParamsTest.php
@@ -22,6 +22,7 @@ class TableParamsTest extends TestCase
             ->setDimensions($fixtures['dimensions'])
             ->setMetrics($fixtures['metrics'])
             ->setSort($fixtures['sort'])
+            ->setDirectClientLogins($fixtures['direct_client_logins'])
             ->setLimit($fixtures['limit'])
             ->setOffset($fixtures['offset'])
             ->setFilters($fixtures['filters'])
@@ -39,6 +40,7 @@ class TableParamsTest extends TestCase
         $this->assertEquals($fixtures['dimensions'], $comparisonParams->getDimensions());
         $this->assertEquals($fixtures['metrics'], $comparisonParams->getMetrics());
         $this->assertEquals($fixtures['sort'], $comparisonParams->getSort());
+        $this->assertEquals($fixtures['direct_client_logins'], $comparisonParams->getDirectClientLogins());
         $this->assertEquals($fixtures['limit'], $comparisonParams->getLimit());
         $this->assertEquals($fixtures['offset'], $comparisonParams->getOffset());
         $this->assertEquals($fixtures['filters'], $comparisonParams->getFilters());


### PR DESCRIPTION
Согласно документации https://yandex.ru/dev/metrika/doc/api2/api_v1/direct-clicks-docpage/, для запроса данных Директа из Метрики, необходимо указывать параметр direct_client_logins в запросе. Мой коммит внедряет поддержку этого параметра в классе TableParams